### PR TITLE
错题本知识点选择模块更改

### DIFF
--- a/source/widget/Public.Selector/index.tpl
+++ b/source/widget/Public.Selector/index.tpl
@@ -79,10 +79,12 @@
                     
             </dd>
             <dt class="choice-more col-xs-3 col-sm-2 col-md-2  clearfix">
-                <div class="choice-more-download hide pull-left">
+<!--
+                <div class="choice-more-download pull-left">
                     <a>更多知识点</a>
                     <i class="fa fa-angle-down fa-chevron-down que-body-arrow"></i>
                 </div>
+-->
                 <!--<div class="chocie-point-download left">下载复习笔记</div>-->
             </dt>
         </dl>

--- a/source/widget/Public.Selector/inputSelect.tpl
+++ b/source/widget/Public.Selector/inputSelect.tpl
@@ -71,17 +71,21 @@
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />英语四级</label>
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />英语六级</label>
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />大话西游</label>
+<!--
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />JavaScript设计模式</label>
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />格斗</label>
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />拳皇</label>
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />前端工程</label>
+-->
               
             </dd>
             <dt class="choice-more col-xs-3 col-sm-2 col-md-2 clearfix">
+<!--
                 <div class="choice-more-download pull-right  hide">
                     <a>更多知识点</a>
                     <i class="fa fa-angle-down fa-chevron-down que-body-arrow"></i>
                 </div>
+-->
                 <!--<div class="chocie-point-download left">下载复习笔记</div>-->
             </dt>
         </dl> 

--- a/source/widget/Public.Selector/inputSelect.tpl
+++ b/source/widget/Public.Selector/inputSelect.tpl
@@ -71,12 +71,10 @@
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />英语四级</label>
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />英语六级</label>
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />大话西游</label>
-<!--
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />JavaScript设计模式</label>
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />格斗</label>
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />拳皇</label>
                 <label class="radio-inline"><input type="radio" value="" name="choice-point-name" class="choice-item-input" />前端工程</label>
--->
               
             </dd>
             <dt class="choice-more col-xs-3 col-sm-2 col-md-2 clearfix">

--- a/source/widget/Public.Selector/selector.js
+++ b/source/widget/Public.Selector/selector.js
@@ -36,14 +36,14 @@ $(select.opti.item).on('click',function(){
     select.chooseSpan(all,thatLi,'active');
 })
 /* 更多知识点按钮是否出现在ajax中判断 */
-if($('.choice-items-spe-input').length){
-    $('.choice-more').removeClass('hide');
-    var height = $('.choice-items-spe').css('height');
-    console.log(height);
-    if(height > '22px'){
-        $('.choice-items-spe').css({'height':'22px'});
-    }
-}
+//if($('.choice-items-spe-input').length){
+//    $('.choice-more').removeClass('hide');
+//    var height = $('.choice-items-spe').css('height');
+//    console.log(height);
+//    if(height > '22px'){
+//        $('.choice-items-spe').css({'height':'22px'});
+//    }
+//}
 
 /* 知识点展示“更多”交互 */
 //$('body').on('click', '.choice-more-download',function(){

--- a/source/widget/Public.Selector/selector.js
+++ b/source/widget/Public.Selector/selector.js
@@ -46,38 +46,38 @@ if($('.choice-items-spe-input').length){
 }
 
 /* 知识点展示“更多”交互 */
-$('body').on('click', '.choice-more-download',function(){
-    var that = this;
-    if($(that).hasClass('show-choice')){
-        $(that).children('a').html('更多知识点');
-        $(that).children('i').removeClass('fa-angle-up fa-chevron-up').addClass('fa-angle-down fa-chevron-down');
-        if($(select.opti.itemSpe).length){
-            $(select.opti.itemSpe).scrollTop(0);
-            $(select.opti.itemSpe).removeClass('choice-items-open');    
-        }else{
-            $(select.opti.pointInput).css({
-                'height':'22px',
-                'overflow':'hidden'
-            }); 
-            
-        }
-        
-        $(that).removeClass('show-choice');
-    }else{
-        $(that).children('a').html('收起知识点');
-        $(that).children('i').removeClass('fa-angle-down fa-chevron-down').addClass('fa-angle-up fa-chevron-up');
-        if($(select.opti.itemSpe).length){
-            $(select.opti.itemSpe).addClass('choice-items-open');    
-        }else{
-            $(select.opti.pointInput).css({
-                'height':'74px',
-                'overflow':'auto'
-            })
-        }
-        
-        $(that).addClass('show-choice');
-    }
-})
+//$('body').on('click', '.choice-more-download',function(){
+//    var that = this;
+//    if($(that).hasClass('show-choice')){
+//        $(that).children('a').html('更多知识点');
+//        $(that).children('i').removeClass('fa-angle-up fa-chevron-up').addClass('fa-angle-down fa-chevron-down');
+//        if($(select.opti.itemSpe).length){
+//            $(select.opti.itemSpe).scrollTop(0);
+//            $(select.opti.itemSpe).removeClass('choice-items-open');    
+//        }else{
+//            $(select.opti.pointInput).css({
+//                'height':'22px',
+//                'overflow':'hidden'
+//            }); 
+//            
+//        }
+//        
+//        $(that).removeClass('show-choice');
+//    }else{
+//        $(that).children('a').html('收起知识点');
+//        $(that).children('i').removeClass('fa-angle-down fa-chevron-down').addClass('fa-angle-up fa-chevron-up');
+//        if($(select.opti.itemSpe).length){
+//            $(select.opti.itemSpe).addClass('choice-items-open');    
+//        }else{
+//            $(select.opti.pointInput).css({
+//                'height':'74px',
+//                'overflow':'auto'
+//            })
+//        }
+//        
+//        $(that).addClass('show-choice');
+//    }
+//})
 
 
 

--- a/source/widget/Public.Selector/selector.less
+++ b/source/widget/Public.Selector/selector.less
@@ -99,13 +99,15 @@
             letter-spacing: 0.3rem;
         }
         .choice-items-spe{//普通情况下的
-            overflow: hidden;
+//            overflow: hidden;
 //            height:2rem;
             margin-top: 1rem;
             margin-bottom: 1rem;
+            max-height:98px;
+            overflow: auto;
             .choice-item-each{
                 line-height: 1;
-                margin-bottom: 1rem;
+                margin-bottom: 10px;
                 .choiceSetting;
                 cursor: pointer;
             }
@@ -117,8 +119,9 @@
         }
         .choice-items-spe-input{//input框所添加的特殊类名
             margin-top: 1.2rem;
-            margin-bottom: 1.2rem;
-//            height:1.8rem;
+            margin-bottom: 0;
+            max-height:88px;
+            overflow: auto;
         }
         .choice-items-open{
             overflow: auto;

--- a/source/widget/UserHome.learning/study-course.less
+++ b/source/widget/UserHome.learning/study-course.less
@@ -233,10 +233,10 @@
 }
 
 .class_test address,
-cite,
-dfn,
-em,
-var {
+.class_test cite,
+.class_test dfn,
+.class_test em,
+.class_test var {
   font-style: normal;
 }
 .class_test .btn_red {
@@ -439,11 +439,11 @@ var {
   padding: 0 0 0 70px;
   background: url("http://img04.xesimg.com/wrong_icon_analysis.png") no-repeat left 0px top 10px;
 }
-.class_answer ul, li {
+.class_answer ul,.class_answer li {
     list-style: none;
 }
 .class_answer a,
-a:link {
+.class_answer a:link {
   text-decoration: none;
   color: #0076b3;
 }


### PR DESCRIPTION
知识点选择模块去除“更多知识点”选项
原因：
1、知识点元素个数不定，如果按照之前的做法，需要在元素插入之后才判断元素是否为一行还是两行，如果是页面跳转则不好判断。
2、做两次判断，影响性能。去除之后，直接利用css的maxheight属性判断就行